### PR TITLE
fix null reference access in addDetailedAppControls

### DIFF
--- a/PowerDocu.AppDocumenter/AppMarkdownBuilder.cs
+++ b/PowerDocu.AppDocumenter/AppMarkdownBuilder.cs
@@ -269,7 +269,7 @@ namespace PowerDocu.AppDocumenter
                 screenDocuments.TryGetValue(screen.Name, out MdDocument screenDoc);
                 screenDoc.Root.Add(new MdHeading(screen.Name, 2));
                 addAppControlsTable(screen, screenDoc);
-                foreach (ControlEntity control in content.appControls.allControls.Where(o => o.Type != "appinfo" && o.Type != "screen" && o.Screen().Equals(screen)).OrderBy(o => o.Name).ToList())
+                foreach (ControlEntity control in content.appControls.allControls.Where(o => o.Type != "appinfo" && o.Type != "screen" && screen.Equals(o.Screen())).OrderBy(o => o.Name).ToList())
                 {
                     screenDoc.Root.Add(new MdHeading(control.Name, 2));
                     addAppControlsTable(control, screenDoc);


### PR DESCRIPTION
Just used this program to run over a solution, and it threw an exception in this specific line: `o.Screen()` returned null.

By swapping where the Equals is called upon this exception no longer triggers and the program *seems* to run fine.

However since I don't know the architecture of this program, there could be a better fix, or this fix could have even more unintended side effects ... if there is, please let me know!