### PR TITLE
fix: repair truncated .sln entry + add a minimal CI build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore PowerDocu.sln
+
+      - name: Build
+        run: dotnet build PowerDocu.sln -c Release --no-restore

--- a/PowerDocu.sln
+++ b/PowerDocu.sln
@@ -23,7 +23,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerDocu.AIModelDocumenter
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerDocu.BPFDocumenter", "PowerDocu.BPFDocumenter\PowerDocu.BPFDocumenter.csproj", "{D8E1F2A3-B4C5-6D7E-8F9A-0B1C2D3E4F5A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerDocu.DesktopFlowDocumenter", "PowerDocu.De
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerDocu.DesktopFlowDocumenter", "PowerDocu.DesktopFlowDocumenter\PowerDocu.DesktopFlowDocumenter.csproj", "{AFA444CF-CC6C-40B3-B4FE-6F627A3FF888}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerDocu.ClassicWorkflowDocumenter", "PowerDocu.ClassicWorkflowDocumenter\PowerDocu.ClassicWorkflowDocumenter.csproj", "{1E92CCC5-56CF-46C9-BB4F-EDBC3D4FCC57}"
 EndProject


### PR DESCRIPTION
Two commits, small and related:

**1. PowerDocu.sln repair.** Line 26's project declaration for PowerDocu.DesktopFlowDocumenter is truncated mid-path on main (ends at 'PowerDocu.De'), which makes the solution unparseable for dotnet restore/build (MSB5013). Its configuration rows survived further down under {AFA444CF-CC6C-40B3-B4FE-6F627A3FF888}, so the line is completed with that original GUID — a one-line change, nothing else touched. (Visual Studio tolerates/heals this quietly, which is probably why it went unnoticed — plain dotnet CLI does not.)

**2. A minimal build check** (.github/workflows/build.yml): checkout with submodules: recursive (catches the fresh-clone 'project not found' pitfall documented in CLAUDE.md's Common Pitfalls), .NET 10, restore + build in Release on every push/PR to main.

The workflow found the .sln issue on its very first run — red before the fix, green after: https://github.com/sbarsbars/PowerDocu/actions/runs/29659993520 (same commits, run on my fork so you don't burn approval clicks on a red run).

Deliberately minimal — no tests (none exist yet to run), no packaging, one job. Happy to adjust the .NET version pin or triggers if you'd prefer different ones.